### PR TITLE
Clean up test behavior and warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+markers = [
+    "adventureworks",
+    "adventureworks_execution",
+]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-cov

--- a/tests/adventureworks/conftest.py
+++ b/tests/adventureworks/conftest.py
@@ -41,11 +41,11 @@ def can_bind(hostname, port):
 
 @fixture(scope="session")
 def local_express_flag():
-    try:
+    if os.environ.get("PYPREQL_INTEGRATION_SQLSERVER_EXPRESS", None) == "true":
         return create_engine(
             "mssql://*server_name*\\SQLEXPRESS/*database_name*?trusted_connection=yes"
         )
-    except Exception as e:
+    else:
         return False
 
 


### PR DESCRIPTION
## Description

Have the flag for using the non-default local sqlexpress server for integration tests be set by a magic env variable, as it's a non default case and the prior implementation resulted in that flag always being set.

Additionally, include a pyproject.toml to register custom test markers and address pytest warnings


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
