### PR TITLE
Improved Property Handling

### DIFF
--- a/preql/__init__.py
+++ b/preql/__init__.py
@@ -2,6 +2,6 @@ from preql.executor import Executor, Dialects
 from preql.parser import parse
 from preql.core.models import Environment
 
-__version__ = "0.0.1-rc.7"
+__version__ = "0.0.1-rc.8"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment"]

--- a/preql/core/models.py
+++ b/preql/core/models.py
@@ -190,11 +190,14 @@ class ColumnAssignment:
         return Modifier.PARTIAL not in self.modifiers
 
     def with_namespace(self, namespace: str) -> "ColumnAssignment":
-        return ColumnAssignment(
-            alias=self.alias,
-            concept=self.concept.with_namespace(namespace),
-            modifiers=self.modifiers,
-        )
+        # this breaks assignments
+        # TODO: figure out why
+        return self
+        # return ColumnAssignment(
+        #     alias=self.alias,
+        #     concept=self.concept.with_namespace(namespace),
+        #     modifiers=self.modifiers,
+        # )
 
 
 @dataclass(eq=True, frozen=True)

--- a/preql/core/models.py
+++ b/preql/core/models.py
@@ -1,9 +1,7 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Dict, MutableMapping, TypeVar
-from typing import List, Optional, Union, Set
-
+from typing import Dict, MutableMapping, TypeVar, List, Optional, Union, Set
 from pydantic import BaseModel, validator, Field
 
 from preql.core.enums import (
@@ -504,6 +502,14 @@ class Datasource:
     @property
     def concepts(self) -> List[Concept]:
         return [c.concept for c in self.columns]
+
+    @property
+    def full_concepts(self) -> List[Concept]:
+        return [c.concept for c in self.columns if Modifier.PARTIAL not in c.modifiers]
+
+    @property
+    def partial_concepts(self) -> List[Concept]:
+        return [c.concept for c in self.columns if Modifier.PARTIAL in c.modifiers]
 
     def get_alias(
         self, concept: Concept, use_raw_name: bool = True, force_alias: bool = False

--- a/preql/core/processing/concept_strategies.py
+++ b/preql/core/processing/concept_strategies.py
@@ -146,10 +146,12 @@ def get_datasource_from_group_select(
             # if the dataset that can reach every concept
             # is in fact a subset of the concept
             # assume property lookup
-            if datasource.grain.issubset(grain):
-                final_grain = datasource.grain
-            else:
-                final_grain = grain
+            # 2023-02-01 - cannot assume this
+            # if datasource.grain.issubset(grain):
+            #     final_grain = datasource.grain
+            # else:
+            #     final_grain = grain
+            final_grain = grain
             logger.debug(
                 f"got {datasource.identifier} for {concept} from grouped select"
             )

--- a/preql/core/processing/concept_strategies.py
+++ b/preql/core/processing/concept_strategies.py
@@ -76,13 +76,21 @@ def get_datasource_from_property_lookup(
     grain: Grain,
     environment: Environment,
     g: ReferenceGraph,
-    is_filter: bool = False,
+    whole_grain: bool = False,
 ) -> QueryDatasource:
-    """Return a datasource that can be grouped to a value and grain.
-    Think unique order ids in order product table."""
-    all_concepts = concept_to_inputs(concept)+ grain.components
+    """Return a datasource that has a direct property/key relation
+    If the datasource is a component of the grain, assume we can
+    join it in the final query to the grain level"""
+    all_concepts = concept_to_inputs(concept)
     for datasource in environment.datasources.values():
-        if datasource.grain.issubset(grain):
+        # whole grain determins
+        # if we can get a partial grain match
+        # such as joining through a table with a PK to get properties
+        # sometimes we need a source with all grain keys, in which case we
+        # force this not to match
+        if datasource.grain.issubset(grain) and (
+            datasource.grain == grain or not whole_grain
+        ):
             all_found = True
             for req_concept in all_concepts:
                 try:
@@ -99,7 +107,7 @@ def get_datasource_from_property_lookup(
                     break
             if all_found:
                 logger.debug(f"Can satisfy query from property lookup for {concept}")
-                if is_filter:
+                if whole_grain:
                     outputs = datasource.grain.components
                     filters = [concept]
                 else:
@@ -117,13 +125,12 @@ def get_datasource_from_property_lookup(
     raise ValueError(f"No property lookup for {concept}")
 
 
-
 def get_datasource_from_group_select(
     concept: Concept,
     grain: Grain,
     environment: Environment,
     g: ReferenceGraph,
-    is_filter: bool = False,
+    whole_grain: bool = False,
 ) -> QueryDatasource:
     """Return a datasource that can be grouped to a value and grain.
     Unique values in a column, for example"""
@@ -156,7 +163,7 @@ def get_datasource_from_group_select(
             logger.debug(
                 f"got {datasource.identifier} for {concept} from grouped select"
             )
-            if is_filter:
+            if whole_grain:
                 outputs = grain.components
                 filters = [concept]
             else:
@@ -179,7 +186,7 @@ def get_datasource_by_joins(
     grain: Grain,
     environment: Environment,
     g: ReferenceGraph,
-    is_filter: bool = False,
+    whole_grain: bool = False,
 ) -> QueryDatasource:
     join_candidates: List[PathInfo] = []
 
@@ -221,7 +228,6 @@ def get_datasource_by_joins(
         root = datasource_nodes[-1]
         source_concept = g.nodes[value[-1]]["concept"]
         parents.append(source_concept)
-
         new_joins = path_to_joins(value, g=g)
 
         join_paths += new_joins
@@ -234,7 +240,7 @@ def get_datasource_by_joins(
                 source_map[jconcept.address].add(join.right_datasource)
                 all_requirements.append(jconcept)
     all_requirements = unique(all_requirements, "address")
-    if is_filter:
+    if whole_grain:
         outputs = grain.components
         filters = [concept]
     else:
@@ -257,7 +263,7 @@ def get_datasource_by_joins(
 
 
 def get_datasource_from_complex_lineage(
-    concept: Concept, grain: Grain, environment, g, is_filter: bool = False
+    concept: Concept, grain: Grain, environment, g, whole_grain: bool = False
 ):
     # always true if window item
     complex_lineage_flag = isinstance(concept.lineage, WindowItem)
@@ -310,51 +316,80 @@ def get_datasource_from_complex_lineage(
         return qds
 
 
-
-
 def get_property_group_by_without_key(
-        concept: Concept, grain: Grain, environment, g, is_filter: bool = False
+    concept: Concept, grain: Grain, environment, g, whole_grain: bool = False
 ):
-    '''If a query requires things at a property grain, but does not include the property
-    key - first search for a query at target grain with all keys, then group up to the property level'''
+    """If a query requires things at a property grain, but does not include the property
+    key - first search for a query at target grain with all keys, then group up to the property level"""
     all_requirements = []
     all_datasets = []
     source_map = {}
-    joins:List[BaseJoin] = []
-    # early exit if no propties
+    joins: List[BaseJoin] = []
+    # early exit if no properties in the grain
     if not any([x.purpose == Purpose.PROPERTY for x in grain.components]):
-        raise ValueError('Cannot find property lookup')
-    pgrain = Grain(components = [z if z.purpose != Purpose.PROPERTY else z.with_default_grain().grain.components[0] for z in grain.components ])
-    # this is our base datasource
-    sub_datasource = get_datasource_by_concept_and_grain(    concept,
-                                                   grain = pgrain,
-                                                   environment= environment,
-                                                   g=g, is_filter=is_filter)
+        raise ValueError("Cannot find property lookup")
+    pgrain = Grain(
+        components=[
+            z
+            if z.purpose != Purpose.PROPERTY
+            else z.with_default_grain().grain.components[0]
+            for z in grain.components
+        ]
+    )
+    # we require this sub datasource to match on all grain components
+    sub_datasource = get_datasource_by_concept_and_grain(
+        concept.with_default_grain().grain.components[0],
+        grain=pgrain,
+        environment=environment,
+        g=g,
+        whole_grain=True,
+    )
     all_datasets.append(sub_datasource)
     all_requirements.append(concept)
     source_map[concept.name] = {sub_datasource}
     if isinstance(sub_datasource, QueryDatasource):
         source_map = {**source_map, **sub_datasource.source_map}
     remapped = [z for z in grain.components if z.purpose == Purpose.PROPERTY]
+    output_concepts = sub_datasource.output_concepts
     for remapped_property in remapped:
-        keys = remapped_property.with_default_grain().grain.components
+        # we don't need another source if we already have this
+        if remapped_property in sub_datasource.output_concepts:
+            continue
+        remap_grain = remapped_property.with_default_grain().grain
+        keys = remap_grain.components
         for key in keys:
             all_requirements.append(key)
-        remapped_datasource = get_datasource_by_concept_and_grain(    remapped_property,
-                                                grain = remapped_property.with_default_grain().grain,
-                                                environment= environment,
-                                                g=g, is_filter=is_filter)
+        # this may not have all keys
+        remapped_datasource = get_datasource_by_concept_and_grain(
+            remapped_property,
+            grain=remap_grain,
+            environment=environment,
+            g=g,
+            whole_grain=whole_grain,
+        )
+        output_concepts = unique(
+            output_concepts + remapped_datasource.output_concepts, "address"
+        )
         all_datasets.append(remapped_datasource)
         all_requirements.append(remapped_property)
         source_map[remapped_property.name] = {remapped_datasource}
         if isinstance(remapped_datasource, QueryDatasource):
             source_map = {**source_map, **remapped_datasource.source_map}
-        joins.append(BaseJoin(
-            left_datasource=sub_datasource,
-            right_datasource=remapped_datasource,
-            join_type=JoinType.LEFT_OUTER,
-            concepts=remapped_property.with_default_grain().grain.components,
-        ))
+        join_concepts = [
+            k
+            for k in keys
+            if k in remapped_datasource.output_concepts
+            and k in sub_datasource.output_concepts
+        ]
+        if join_concepts:
+            joins.append(
+                BaseJoin(
+                    left_datasource=sub_datasource,
+                    right_datasource=remapped_datasource,
+                    join_type=JoinType.LEFT_OUTER,
+                    concepts=join_concepts,
+                )
+            )
     qds = QueryDatasource(
         output_concepts=[concept] + grain.components,
         input_concepts=all_requirements,
@@ -367,8 +402,9 @@ def get_property_group_by_without_key(
     source_map[concept.name] = {qds}
     return qds
 
+
 def get_datasource_from_window_function(
-    concept: Concept, grain: Grain, environment, g, is_filter: bool = False
+    concept: Concept, grain: Grain, environment, g, whole_grain: bool = False
 ):
     if not isinstance(concept.lineage, WindowItem):
         raise ValueError(
@@ -427,7 +463,7 @@ def get_datasource_by_concept_and_grain(
     grain: Grain,
     environment: Environment,
     g: Optional[ReferenceGraph] = None,
-    is_filter: bool = False,
+    whole_grain: bool = False,
 ) -> Union[Datasource, QueryDatasource]:
     """Determine if it's possible to get a certain concept at a certain grain.
     """
@@ -436,12 +472,12 @@ def get_datasource_by_concept_and_grain(
         if concept.derivation == PurposeLineage.WINDOW:
             logger.debug("Checking for complex window function")
             complex = get_datasource_from_window_function(
-                concept, grain, environment, g, is_filter=is_filter
+                concept, grain, environment, g, whole_grain=whole_grain
             )
         elif concept.derivation == PurposeLineage.AGGREGATE:
             logger.debug("Checking for complex function derivation")
             complex = get_datasource_from_complex_lineage(
-                concept, grain, environment, g, is_filter=is_filter
+                concept, grain, environment, g, whole_grain=whole_grain
             )
         else:
             complex = None
@@ -454,7 +490,11 @@ def get_datasource_by_concept_and_grain(
         try:
 
             out = get_datasource_from_property_lookup(
-                concept.with_default_grain(), grain, environment, g, is_filter=is_filter
+                concept.with_default_grain(),
+                grain,
+                environment,
+                g,
+                whole_grain=whole_grain,
             )
             logger.debug(f"Got {concept} from property lookup")
             return out
@@ -463,7 +503,7 @@ def get_datasource_by_concept_and_grain(
     # the concept is available on a datasource, but at a higher granularity
     try:
         out = get_datasource_from_group_select(
-            concept, grain, environment, g, is_filter=is_filter
+            concept, grain, environment, g, whole_grain=whole_grain
         )
         logger.debug(f"Got {concept} from grouped select")
         return out
@@ -473,7 +513,7 @@ def get_datasource_by_concept_and_grain(
     # a join from a root dataset to enrichment datasets
     try:
         out = get_datasource_by_joins(
-            concept, grain, environment, g, is_filter=is_filter
+            concept, grain, environment, g, whole_grain=whole_grain
         )
         logger.debug(f"Got {concept} from joins")
         return out
@@ -490,19 +530,22 @@ def get_datasource_by_concept_and_grain(
                     grain,
                     environment,
                     g,
-                    is_filter=is_filter,
+                    whole_grain=whole_grain,
                 )
                 logger.debug(f"Got {concept} from join to a sub portion of grain")
                 return out
             except ValueError as e:
                 logger.debug(e)
 
-
     # if there is a property in the grain, see if we can find a datasource
     # with all the keys of the property, which we can then join to
     try:
-        out = get_property_group_by_without_key(  concept, grain, environment, g, is_filter=is_filter)
-        logger.debug(f"Got {concept} from property lookup via transversing key based grain")
+        out = get_property_group_by_without_key(
+            concept, grain, environment, g, whole_grain=whole_grain
+        )
+        logger.debug(
+            f"Got {concept} from property lookup via transversing key based grain"
+        )
         return out
     except ValueError as e:
         logger.debug(e)

--- a/preql/core/query_processor.py
+++ b/preql/core/query_processor.py
@@ -139,14 +139,14 @@ def get_query_datasources(
         # TODO: figure out right place to group to do predicate pushdown
         statement.grain.components += statement.where_clause.input
 
-    # we don't actually use is_filter latest filter design
+    # we don't actually use whole_grain latest filter design
     # but retain this to enable improved predicate pushdown in the future
     components = {False: statement.output_components + statement.grain.components}
 
     for key, concept_list in components.items():
         for concept in concept_list:
             datasource = get_datasource_by_concept_and_grain(
-                concept, statement.grain, environment, graph, is_filter=key
+                concept, statement.grain, environment, graph, whole_grain=key
             )
 
             if concept not in concept_map[datasource.identifier]:
@@ -178,14 +178,13 @@ def process_query(
 
     final_ctes = merge_ctes(ctes)
 
-
-    base_list:List[CTE] = [cte for cte in final_ctes if cte.grain == statement.grain]
+    base_list: List[CTE] = [cte for cte in final_ctes if cte.grain == statement.grain]
     if base_list:
         base = base_list[0]
     else:
         base_list = [cte for cte in ctes if cte.grain.issubset(statement.grain)]
         base = base_list[0]
-    others:List[CTE] = [cte for cte in final_ctes if cte != base]
+    others: List[CTE] = [cte for cte in final_ctes if cte != base]
 
     for cte in others:
         # we do the with_grain here to fix an issue
@@ -193,7 +192,9 @@ def process_query(
         # with the default key grain rather than the grain of the select
         # TODO - evaluate if we can fix this in select definition
         joinkeys = [
-            JoinKey(c) for c in statement.grain.components if c.with_grain(statement.grain) in cte.output_columns
+            JoinKey(c)
+            for c in statement.grain.components
+            if c.with_grain(statement.grain) in cte.output_columns
         ]
         if joinkeys:
             joins.append(

--- a/preql/dialect/sql_server.py
+++ b/preql/dialect/sql_server.py
@@ -23,6 +23,7 @@ from preql.core.models import (
 from preql.core.models import Environment, Select
 from preql.core.query_processor import process_query
 from preql.dialect.common import render_join
+
 WINDOW_FUNCTION_MAP = {
     WindowType.ROW_NUMBER: lambda window, sort, order: f"row_number() over ( order by {sort} {order})"
 }
@@ -78,6 +79,7 @@ MAX_IDENTIFIER_LENGTH = 128
 
 from preql.utility import string_to_hash
 
+
 class SqlServerDialect(BaseDialect):
     WINDOW_FUNCTION_MAP = WINDOW_FUNCTION_MAP
     FUNCTION_MAP = FUNCTION_MAP
@@ -85,11 +87,13 @@ class SqlServerDialect(BaseDialect):
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = TSQL_TEMPLATE
 
-
     def compile_statement(self, query: ProcessedQuery) -> str:
         base = super().compile_statement(query)
         for cte in query.ctes:
-            if len(cte.name)>MAX_IDENTIFIER_LENGTH:
-                new_name = f'rhash_{string_to_hash(cte.name)}'
+            if len(cte.name) > MAX_IDENTIFIER_LENGTH:
+                print("replacing")
+                print(cte.name)
+                new_name = f"rhash_{string_to_hash(cte.name)}"
+                print(new_name)
                 base = base.replace(cte.name, new_name)
         return base

--- a/preql/dialect/sql_server.py
+++ b/preql/dialect/sql_server.py
@@ -2,7 +2,27 @@ from jinja2 import Template
 
 from preql.core.enums import FunctionType, WindowType
 from preql.dialect.base import BaseDialect
+from typing import List, Union, Optional, Dict
 
+from jinja2 import Template
+
+from preql.core.enums import FunctionType, WindowType, PurposeLineage, JoinType
+from preql.core.hooks import BaseProcessingHook
+from preql.core.models import (
+    Concept,
+    CTE,
+    ProcessedQuery,
+    CompiledCTE,
+    Conditional,
+    Expr,
+    Comparison,
+    Function,
+    OrderItem,
+    WindowItem,
+)
+from preql.core.models import Environment, Select
+from preql.core.query_processor import process_query
+from preql.dialect.common import render_join
 WINDOW_FUNCTION_MAP = {
     WindowType.ROW_NUMBER: lambda window, sort, order: f"row_number() over ( order by {sort} {order})"
 }
@@ -54,6 +74,9 @@ ORDER BY {% for order in order_by %}
 """
 )
 
+MAX_IDENTIFIER_LENGTH = 128
+
+from preql.utility import string_to_hash
 
 class SqlServerDialect(BaseDialect):
     WINDOW_FUNCTION_MAP = WINDOW_FUNCTION_MAP
@@ -61,3 +84,12 @@ class SqlServerDialect(BaseDialect):
     FUNCTION_GRAIN_MATCH_MAP = FUNCTION_GRAIN_MATCH_MAP
     QUOTE_CHARACTER = '"'
     SQL_TEMPLATE = TSQL_TEMPLATE
+
+
+    def compile_statement(self, query: ProcessedQuery) -> str:
+        base = super().compile_statement(query)
+        for cte in query.ctes:
+            if len(cte.name)>MAX_IDENTIFIER_LENGTH:
+                new_name = f'rhash_{string_to_hash(cte.name)}'
+                base = base.replace(cte.name, new_name)
+        return base

--- a/preql/parsing/parse_engine.py
+++ b/preql/parsing/parse_engine.py
@@ -267,7 +267,7 @@ class ParseToObjects(Transformer):
             metadata=metadata,
             grain=Grain(components=[self.environment.concepts[grain]]),
             namespace=self.environment.namespace,
-            keys = [self.environment.concepts[grain]]
+            keys=[self.environment.concepts[grain]],
         )
         self.environment.concepts[name] = concept
         return args
@@ -413,7 +413,7 @@ class ParseToObjects(Transformer):
             lineage=function,
             namespace=namespace,
             grain=grain,
-            keys = keys
+            keys=keys,
         )
         # We don't assign it here because we'll do this later when we know the grain
         self.environment.concepts[lookup] = concept

--- a/preql/parsing/parse_engine.py
+++ b/preql/parsing/parse_engine.py
@@ -10,6 +10,7 @@ from lark.exceptions import (
     UnexpectedInput,
     UnexpectedToken,
 )
+from preql.core.exceptions import UndefinedConceptException, InvalidSyntaxException
 
 from preql.core.enums import (
     Purpose,
@@ -266,6 +267,7 @@ class ParseToObjects(Transformer):
             metadata=metadata,
             grain=Grain(components=[self.environment.concepts[grain]]),
             namespace=self.environment.namespace,
+            keys = [self.environment.concepts[grain]]
         )
         self.environment.concepts[name] = concept
         return args
@@ -398,12 +400,20 @@ class ParseToObjects(Transformer):
             raise ParseError(
                 f"Assignment to concept {output} on line {meta.line} is a duplicate declaration for this concept"
             )
+        if function.output_purpose == Purpose.PROPERTY:
+            grain = Grain(components=function.arguments)
+            keys = function.arguments
+        else:
+            grain = None
+            keys = None
         concept = Concept(
             name=output,
             datatype=function.output_datatype,
             purpose=function.output_purpose,
             lineage=function,
             namespace=namespace,
+            grain=grain,
+            keys = keys
         )
         # We don't assign it here because we'll do this later when we know the grain
         self.environment.concepts[lookup] = concept
@@ -430,7 +440,7 @@ class ParseToObjects(Transformer):
         return [arg for arg in args if arg]
 
     def limit(self, args):
-        return Limit(count=args[0].value)
+        return Limit(count=int(args[0].value))
 
     def ORDERING(self, args):
         return Ordering(args)
@@ -581,6 +591,7 @@ class ParseToObjects(Transformer):
             arguments=args,
             output_datatype=DataType.INTEGER,
             output_purpose=Purpose.METRIC,
+            arg_count=1,
         )
 
     def count_distinct(self, args):
@@ -589,63 +600,61 @@ class ParseToObjects(Transformer):
             arguments=args,
             output_datatype=DataType.INTEGER,
             output_purpose=Purpose.METRIC,
+            arg_count=1,
         )
 
     def sum(self, arguments):
-        if not len(arguments) == 1:
-            raise ParseError("Too many arguments to sum")
         return Function(
             operator=FunctionType.SUM,
             arguments=arguments,
             output_datatype=arguments[0].datatype,
             output_purpose=Purpose.METRIC,
+            arg_count=1
             # output_grain=Grain(components=arguments),
         )
 
     def avg(self, arguments):
-        if not len(arguments) == 1:
-            raise ParseError("Too many arguments to avg")
+
+        arg = arguments[0]
+
         return Function(
             operator=FunctionType.AVG,
             arguments=arguments,
-            output_datatype=arguments[0].datatype,
+            output_datatype=arg.datatype,
             output_purpose=Purpose.METRIC,
-            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER}
+            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER},
+            arg_count=1
             # output_grain=Grain(components=arguments),
         )
 
     def max(self, arguments):
-        if not len(arguments) == 1:
-            raise ParseError("Too many arguments to max")
         return Function(
             operator=FunctionType.MIN,
             arguments=arguments,
             output_datatype=arguments[0].datatype,
             output_purpose=Purpose.METRIC,
-            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER}
+            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER},
+            arg_count=1
             # output_grain=Grain(components=arguments),
         )
 
     def min(self, arguments):
-        if not len(arguments) == 1:
-            raise ParseError("Too many arguments to min")
         return Function(
             operator=FunctionType.MAX,
             arguments=arguments,
             output_datatype=arguments[0].datatype,
             output_purpose=Purpose.METRIC,
-            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER}
+            valid_inputs={DataType.INTEGER, DataType.FLOAT, DataType.NUMBER},
+            arg_count=1
             # output_grain=Grain(components=arguments),
         )
 
     def len(self, args):
-        if not len(args) == 1:
-            raise ParseError("Too many arguments to len")
         return Function(
             operator=FunctionType.LENGTH,
             arguments=args,
-            output_datatype=args[0].datatype,
-            output_purpose=Purpose.METRIC,
+            output_datatype=DataType.INTEGER,
+            output_purpose=Purpose.PROPERTY,
             valid_inputs={DataType.STRING, DataType.ARRAY, DataType.MAP},
             # output_grain=args[0].grain,
         )
@@ -655,25 +664,22 @@ class ParseToObjects(Transformer):
             operator=FunctionType.CONCAT,
             arguments=args,
             output_datatype=args[0].datatype,
-            output_purpose=Purpose.KEY,
+            output_purpose=Purpose.PROPERTY,
             valid_inputs={DataType.STRING},
+            arg_count=99
             # output_grain=args[0].grain,
         )
 
     def like(self, args):
-        if not len(args) == 2:
-            raise ParseError("The Like function expects two arguments")
         return Function(
             operator=FunctionType.LIKE,
             arguments=args,
             output_datatype=DataType.BOOL,
             output_purpose=Purpose.PROPERTY,
             valid_inputs={DataType.STRING},
+            arg_count=2
             # output_grain=Grain(components=args),
         )
-
-
-from preql.core.exceptions import UndefinedConceptException, InvalidSyntaxException
 
 
 def parse_text(

--- a/tests/adventureworks/conftest.py
+++ b/tests/adventureworks/conftest.py
@@ -8,7 +8,10 @@ from urllib.parse import quote_plus
 
 from pytest import fixture
 from sqlalchemy.engine import create_engine
+from preql.constants import logger
+from logging import DEBUG
 
+logger.setLevel(DEBUG)
 from preql import Executor, Dialects, Environment
 
 

--- a/tests/adventureworks/online_sales_queries.preql
+++ b/tests/adventureworks/online_sales_queries.preql
@@ -7,9 +7,7 @@ import concepts.sales_territory as sales_territory;
 
 select
     dates.order_date,
-    dates.order_key,
     customer.first_name,
-    customer.customer_id,
     internet_sales.total_order_quantity,
     internet_sales.total_sales_amount
 order by

--- a/tests/adventureworks/online_sales_queries.preql
+++ b/tests/adventureworks/online_sales_queries.preql
@@ -3,6 +3,20 @@ import concepts.customer as customer;
 import concepts.dates as dates;
 import concepts.sales_territory as sales_territory;
 
+
+
+select
+    dates.order_date,
+    dates.order_key,
+    customer.first_name,
+    customer.customer_id,
+    internet_sales.total_order_quantity,
+    internet_sales.total_sales_amount
+order by
+    internet_sales.total_sales_amount desc
+limit 100;
+
+
 select
     customer.first_name,
     customer.last_name,
@@ -14,21 +28,12 @@ limit 100;
 
 
 select
-    dates.order_date,
     customer.first_name,
-    internet_sales.total_order_quantity,
-    internet_sales.total_sales_amount
-order by
-    internet_sales.total_sales_amount desc
-limit 100;
-
-
-select
     internet_sales.order_number,
     internet_sales.order_line_number,
     internet_sales.total_sales_amount,
-    sales_territory.region,
-    customer.first_name
+#    sales_territory.region,
+
 order by
     internet_sales.order_number desc
 limit 5;

--- a/tests/adventureworks/test_adventureworks.py
+++ b/tests/adventureworks/test_adventureworks.py
@@ -86,6 +86,7 @@ def test_query_datasources(environment):
     # assert concept_to_node(sales.with_grain) in list(environment_graph.neighbors(datasource_to_node(fact_internet_sales)))
     # assert (concept_to_node(sales),concept_to_node(total_sales), ) in environment_graph.edges()
 
+    default_fact = 'fact_internet_sales_at_internet_sales_order_number_internet_sales_order_line_number_sales_territory_key_customer_customer_id'
     for concept in test.output_components:
         datasource = get_datasource_by_concept_and_grain(
             concept, test.grain, environment, environment_graph
@@ -98,17 +99,17 @@ def test_query_datasources(environment):
         elif concept.name == "order_number":
             assert (
                 datasource.identifier
-                == "fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number"
+                == default_fact
             )
         elif concept.name == "order_line_number":
             assert (
                 datasource.identifier
-                == "fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number"
+                == default_fact
             )
         elif concept.name == "total_sales_amount":
             assert (
                 datasource.identifier
-                == "fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number"
+                == default_fact
             )
         elif concept.name == "region":
             assert datasource.identifier == "sales_territories_at_sales_territory_key"

--- a/tests/adventureworks/test_adventureworks.py
+++ b/tests/adventureworks/test_adventureworks.py
@@ -44,6 +44,7 @@ def test_finance_queries(adventureworks_engine, environment):
 def test_query_datasources(environment):
     from preql.constants import logger
     from logging import StreamHandler
+    from preql.core.models import Grain
 
     logger.addHandler(StreamHandler())
 
@@ -59,34 +60,47 @@ def test_query_datasources(environment):
 
     test: Select = statements[-1]  # multipart join
 
+    for item in test.grain.components:
+        print(item)
+    print('-----')
     environment_graph = generate_graph(environment)
+
+    # assert a group up to the first name works
+    customer_datasource = get_datasource_by_concept_and_grain(
+       environment.concepts['customer.first_name'], Grain(components = [environment.concepts['customer.first_name']]), environment, environment_graph
+    )
+
+    assert customer_datasource.identifier == "customers_at_customer_first_name"
+
+    # assert a join before the group by works
+    customer_datasource = get_datasource_by_concept_and_grain(
+        environment.concepts['internet_sales.order_number'], Grain(components = [environment.concepts['internet_sales.order_number'], environment.concepts['customer.first_name']]), environment, environment_graph
+    )
+
+    assert customer_datasource.identifier == "customers_fact_internet_sales_at_internet_sales_order_number_customer_first_name"
+
+    # assert a group up to the first name works
+    customer_datasource = get_datasource_by_concept_and_grain(
+        environment.concepts['customer.first_name'], Grain(components = [environment.concepts['customer.first_name'],environment.concepts['customer.last_name']]), environment, environment_graph
+    )
+
+    assert customer_datasource.identifier == "customers_at_customer_first_name_customer_last_name"
+
+
     concepts, datasources = get_query_datasources(
         environment=environment, graph=environment_graph, statement=test
     )
-    total_sales = environment.concepts["internet_sales.total_sales_amount"]
-    sales = environment.concepts["internet_sales.sales_amount"]
-    fact_internet_sales = environment.datasources["internet_sales.fact_internet_sales"]
 
-    path = nx.shortest_path(
-        environment_graph,
-        "ds~internet_sales.fact_internet_sales",
-        "c~internet_sales.order_quantity@Grain<internet_sales.order_line_number,internet_sales.order_number>",
-    )
     assert "ds~internet_sales.fact_internet_sales" in environment_graph.nodes
     assert (
         "c~internet_sales.total_sales_amount@Grain<Abstract>" in environment_graph.nodes
-    )
-    path = nx.shortest_path(
-        environment_graph,
-        "ds~internet_sales.fact_internet_sales",
-        "c~internet_sales.total_sales_amount@Grain<Abstract>",
     )
     # for val in list(environment_graph.neighbors(datasource_to_node(fact_internet_sales))):
     #     print(val)
     # assert concept_to_node(sales.with_grain) in list(environment_graph.neighbors(datasource_to_node(fact_internet_sales)))
     # assert (concept_to_node(sales),concept_to_node(total_sales), ) in environment_graph.edges()
 
-    default_fact = 'fact_internet_sales_at_internet_sales_order_number_internet_sales_order_line_number_sales_territory_key_customer_customer_id'
+    default_fact = 'fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number'
     for concept in test.output_components:
         datasource = get_datasource_by_concept_and_grain(
             concept, test.grain, environment, environment_graph
@@ -109,39 +123,24 @@ def test_query_datasources(environment):
         elif concept.name == "total_sales_amount":
             assert (
                 datasource.identifier
-                == default_fact
+                == 'customers_fact_internet_sales_at_internet_sales_order_number_internet_sales_order_line_number_customer_first_name'
             )
         elif concept.name == "region":
             assert datasource.identifier == "sales_territories_at_sales_territory_key"
         elif concept.name == "first_name":
-            assert datasource.identifier == "customers_at_customer_customer_id"
+            assert datasource.identifier == "customers_at_customer_customer_id_at_internet_sales_order_number_internet_sales_order_line_number_customer_first_name"
         else:
             raise ValueError(concept)
-    assert set([datasource.identifier for datasource in datasources.values()]) == {
-        "customers_at_customer_customer_id",
-        "fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number",
-        "sales_territories_at_sales_territory_key",
-    }
+    assert set([datasource.identifier for datasource in datasources.values()]) == {'customers_at_customer_customer_id_at_internet_sales_order_number_internet_sales_order_line_number_customer_first_name',
+                                                                                   'customers_fact_internet_sales_at_internet_sales_order_number_internet_sales_order_line_number_customer_first_name',
+                                                                                   'fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number'}
 
-    joined_datasource: QueryDatasource = [
-        ds
-        for ds in datasources.values()
-        if ds.identifier == "customers_at_customer_customer_id"
-    ][0]
-    assert set([c.name for c in joined_datasource.input_concepts]) == {
-        "customer_id",
-        "first_name",
-    }
-    assert set([c.name for c in joined_datasource.output_concepts]) == {
-        "customer_id",
-        "first_name",
-    }
 
     ctes = []
     for datasource in datasources.values():
         ctes += datasource_to_ctes(datasource)
 
-    assert len(ctes) == 3
+    assert len(ctes) == 6
     base_cte: CTE = [
         cte
         for cte in ctes
@@ -149,11 +148,54 @@ def test_query_datasources(environment):
             "cte_fact_internet_sales_at_internet_sales_order_line_number_internet_sales_order_number"
         )
     ][0]
-    assert len(base_cte.output_columns) == 5
+    assert len(base_cte.output_columns) == 2
 
     # the CTE has all grain components
     assert base_cte.group_to_grain == False
 
+
+@pytest.mark.adventureworks
+def test_two_properties(environment):
+    from preql.constants import logger
+    from logging import StreamHandler
+    from preql.core.models import Grain
+
+    logger.addHandler(StreamHandler())
+
+    with open(
+            join(dirname(__file__), "online_sales_queries.preql"), "r", encoding="utf-8"
+    ) as f:
+        file = f.read()
+    environment, statements = parse(file, environment=environment)
+    test: Select = statements[-3]
+
+    for item in test.grain.components:
+        print(item)
+    print('-----')
+    environment_graph = generate_graph(environment)
+
+    # assert a group up to the first name works
+    customer_datasource = get_datasource_by_concept_and_grain(
+        environment.concepts['customer.first_name'], test.grain, environment, environment_graph
+    )
+
+    # assert customer_datasource.identifier == "customers_fact_internet_sales_order_dates_at_dates_order_date_customer_first_name"
+
+    order_date_datasource = get_datasource_by_concept_and_grain(
+        environment.concepts['dates.order_date'], test.grain, environment, environment_graph
+    )
+
+    # assert order_date_datasource.identifier == "customers_fact_internet_sales_order_dates_at_dates_order_date_customer_first_name"
+
+
+    concepts, datasources = get_query_datasources(
+        environment=environment, graph=environment_graph, statement=test
+    )
+
+    generator = SqlServerDialect()
+    sql2 = generator.generate_queries(environment, [test])
+    sql = generator.compile_statement(sql2[0])
+    print(sql)
 
 @pytest.mark.adventureworks_execution
 def test_online_sales_queries(adventureworks_engine, environment):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def test_environment():
         datatype=DataType.INTEGER,
         purpose=Purpose.PROPERTY,
         grain=category_id,
-        lineage = Function(
+        lineage=Function(
             arguments=[category_name],
             output_datatype=DataType.INTEGER,
             output_purpose=Purpose.PROPERTY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,19 @@ def test_environment():
         grain=category_id,
     )
 
+    category_name_length = Concept(
+        name="category_name_length",
+        datatype=DataType.INTEGER,
+        purpose=Purpose.PROPERTY,
+        grain=category_id,
+        lineage = Function(
+            arguments=[category_name],
+            output_datatype=DataType.INTEGER,
+            output_purpose=Purpose.PROPERTY,
+            operator=FunctionType.LENGTH,
+        ),
+    )
+
     # total_revenue =
 
     test_revenue = Datasource(
@@ -125,6 +138,7 @@ def test_environment():
     for item in [
         category_id,
         category_name,
+        category_name_length,
         total_revenue,
         revenue,
         product_id,

--- a/tests/stack_overflow/test_aggregate_grain.py
+++ b/tests/stack_overflow/test_aggregate_grain.py
@@ -29,6 +29,7 @@ order by
 
 select
     core.badge_name,
+    core.badge_id,
     sum(user_badge_count)-> total_badge_user_award_count
 order by
     user_badge_count desc

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -37,5 +37,5 @@ select
     env, parsed = parse(declarations, environment=test_environment)
     select: Select = parsed[-1]
 
-    x= BaseDialect().compile_statement(process_query(test_environment, select))
+    x = BaseDialect().compile_statement(process_query(test_environment, select))
     print(x)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -22,3 +22,20 @@ select
     select: Select = parsed[-1]
 
     BaseDialect().compile_statement(process_query(test_environment, select))
+
+
+def test_wrapped_property_functions(test_environment):
+    declarations = """
+
+select
+    product_id,
+    avg(category_name_length) ->average_category_name_length
+;
+
+
+    """
+    env, parsed = parse(declarations, environment=test_environment)
+    select: Select = parsed[-1]
+
+    x= BaseDialect().compile_statement(process_query(test_environment, select))
+    print(x)

--- a/tests/test_multi_join_assignments.py
+++ b/tests/test_multi_join_assignments.py
@@ -66,7 +66,7 @@ def test_select():
     env, parsed = parse(TEST_SETUP)
     select: Select = parsed[-1]
 
-    assert select.grain == Grain(components=[env.concepts["category_key"]])
+    assert select.grain == Grain(components=[env.concepts["category_name"]])
 
     process_query(statement=select, environment=env, hooks=[GraphHook()])
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -33,23 +33,21 @@ datasource users (
     """
     env, parsed = parse(declarations)
 
-    q1= '''select
+    q1 = """select
     user_id,
     about_me,
     count(post_id)->post_count
-;'''
+;"""
     env, parse_one = parse(q1, environment=env)
 
     select: Select = parse_one[-1]
     assert select.grain == Grain(components=[env.concepts["user_id"]])
 
-    q2= '''select
+    q2 = """select
     about_me,
     post_count
-;'''
+;"""
     env, parse_two = parse(q2, environment=env)
 
     select: Select = parse_two[-1]
     assert select.grain == Grain(components=[env.concepts["about_me"]])
-
-

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -29,15 +29,27 @@ datasource users (
     address bigquery-public-data.stackoverflow.users
 ;
 
-select
-    user_id,
-    about_me,
-    count(post_id)->post_count
-;
-
 
     """
     env, parsed = parse(declarations)
-    select: Select = parsed[-1]
 
+    q1= '''select
+    user_id,
+    about_me,
+    count(post_id)->post_count
+;'''
+    env, parse_one = parse(q1, environment=env)
+
+    select: Select = parse_one[-1]
     assert select.grain == Grain(components=[env.concepts["user_id"]])
+
+    q2= '''select
+    about_me,
+    post_count
+;'''
+    env, parse_two = parse(q2, environment=env)
+
+    select: Select = parse_two[-1]
+    assert select.grain == Grain(components=[env.concepts["about_me"]])
+
+


### PR DESCRIPTION
## Description

Design was previously overopinionated about forcing properties to output at the grain of the related key. While we should preserve properties optimizing to the key grain if in a query together, if the key is not included in the output we should still group up the property itself.

This required refactoring of property grain handling. 

As a followup, we should support more granular property syntax to enable optimization.

Specifically, these two cases should be differentiated.


Unique ID integer date key
Unique Property 1-1 with ID date text 
Non-unique Property 1-many with ID date month

select 
date_key,
date_text,
date_month

should still be treated as grain(datekey)

but select
date_text should be grain(datekey)
and 
date_month should be grain(date_month


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
