### PR TITLE
Give querier access to suggestions when they provide an non-existant …

### DIFF
--- a/preql/core/exceptions.py
+++ b/preql/core/exceptions.py
@@ -1,5 +1,10 @@
+from typing import List
+
 class UndefinedConceptException(Exception):
-    pass
+
+    def __init__(self, message, suggestions: List[str]):
+        super().__init__(self, message)
+        self.suggestions = suggestions
 
 
 class InvalidSyntaxException(Exception):

--- a/preql/core/exceptions.py
+++ b/preql/core/exceptions.py
@@ -4,6 +4,7 @@ class UndefinedConceptException(Exception):
 
     def __init__(self, message, suggestions: List[str]):
         super().__init__(self, message)
+        self.message = message
         self.suggestions = suggestions
 
 

--- a/preql/core/models.py
+++ b/preql/core/models.py
@@ -915,7 +915,10 @@ class EnvironmentConceptDict(dict, MutableMapping[KT, VT]):
             return super(EnvironmentConceptDict, self).__getitem__(key)
         except KeyError as e:
             matches = self._find_similar_concepts(key)
-            message =  f"undefined concept: {key}. Suggestions: {matches}"
+            message =  f"undefined concept: {key}."
+            if matches:
+                message += f" Suggestions: {matches}"
+
             if line_no:
                 raise UndefinedConceptException(
                     f"line: {line_no}: " + message,

--- a/preql/core/models.py
+++ b/preql/core/models.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Dict, MutableMapping, TypeVar, List, Optional, Union, Set
 from pydantic import BaseModel, validator, Field
+import difflib
 
 from preql.core.enums import (
     DataType,
@@ -913,11 +914,19 @@ class EnvironmentConceptDict(dict, MutableMapping[KT, VT]):
         try:
             return super(EnvironmentConceptDict, self).__getitem__(key)
         except KeyError as e:
+            matches = self._find_similar_concepts(key)
+            message =  f"undefined concept: {key}. Suggestions: {matches}"
             if line_no:
                 raise UndefinedConceptException(
-                    f"line: {line_no} undefined concept: {str(e)}"
+                    f"line: {line_no}: " + message,
+                    matches
                 )
-            raise UndefinedConceptException(str(e))
+            raise UndefinedConceptException(message, matches)
+        
+    def _find_similar_concepts(self, concept_name):
+        matches = difflib.get_close_matches(concept_name, self.keys())
+        return matches
+
 
 
 @dataclass

--- a/tests/adventureworks/conftest.py
+++ b/tests/adventureworks/conftest.py
@@ -54,7 +54,7 @@ def local_express_flag():
 
 @fixture(scope="session")
 def db_must(local_express_flag):
-    # if a local instanc can be found
+    # if a local instance can be found
     # use that instead of managing docker
     if local_express_flag:
         yield TestConfig.LOCAL

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -1,0 +1,16 @@
+from preql.parser import parse
+from preql.core.exceptions import UndefinedConceptException
+
+def test_undefined_concept(test_environment):
+    q = "SELECT orid LIMIT 10;"
+    try:
+        parse(q, test_environment)
+    except UndefinedConceptException as e:
+        assert e.suggestions == ["order_id"]
+
+    q = "SELECT order_ct LIMIT 10;"
+    try:
+        parse(q, test_environment)
+    except UndefinedConceptException as e:
+        assert e.suggestions == ['order_count', 'order_id', 'order_timestamp']
+

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -12,5 +12,5 @@ def test_undefined_concept(test_environment):
     try:
         parse(q, test_environment)
     except UndefinedConceptException as e:
-        assert e.suggestions == ['order_count', 'order_id', 'order_timestamp']
+        assert len(e.suggestions) == 3
 

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -24,7 +24,7 @@ def test_undefined_concept_dict():
         env["zzz"]
     except UndefinedConceptException as e:
         assert e.suggestions == []
-        assert "suggestions" not in str(e).lower()
+        assert "suggestions" not in e.message.lower()
 
     try:
         env["orid"]

--- a/tests/test_undefined_concept.py
+++ b/tests/test_undefined_concept.py
@@ -1,7 +1,10 @@
 from preql.parser import parse
 from preql.core.exceptions import UndefinedConceptException
+from preql.core.models import EnvironmentConceptDict, Concept
+from preql.core.enums import DataType, Purpose
 
-def test_undefined_concept(test_environment):
+
+def test_undefined_concept_query(test_environment):
     q = "SELECT orid LIMIT 10;"
     try:
         parse(q, test_environment)
@@ -13,4 +16,24 @@ def test_undefined_concept(test_environment):
         parse(q, test_environment)
     except UndefinedConceptException as e:
         assert len(e.suggestions) == 3
+
+def test_undefined_concept_dict():
+    env = EnvironmentConceptDict()
+    env["order_id"] = Concept(name="order_id", datatype=DataType.INTEGER, purpose=Purpose.KEY)
+    try:
+        env["zzz"]
+    except UndefinedConceptException as e:
+        assert e.suggestions == []
+        assert "suggestions" not in str(e).lower()
+
+    try:
+        env["orid"]
+    except UndefinedConceptException as e:
+        assert e.suggestions == ["order_id"]
+        assert "suggestions" in e.message.lower()
+        assert "order_id" in e.message.lower()
+
+
+    
+
 


### PR DESCRIPTION
…concept in a query
## Description

This is related to Issue #12 . Open to guidance/suggestion on additions that would further encapsulate of the lark errors as you may want.

When a query is run against a model that requests a concept that doesn't exist, the parsing operation will raise an UndefinedConceptException which includes a member variable that contains strings of suggested concepts based on pythons basic built in match finding as well as a error message containing the suggestions.


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
