### PR TITLE
Add in a lazy importable environment

### DIFF
--- a/preql/__init__.py
+++ b/preql/__init__.py
@@ -3,6 +3,6 @@ from preql.dialect.enums import Dialects
 from preql.executor import Executor
 from preql.parser import parse
 
-__version__ = "0.0.1-rc.77"
+__version__ = "0.0.1-rc.76"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment"]

--- a/preql/__init__.py
+++ b/preql/__init__.py
@@ -3,6 +3,6 @@ from preql.dialect.enums import Dialects
 from preql.executor import Executor
 from preql.parser import parse
 
-__version__ = "0.0.1-rc.75"
+__version__ = "0.0.1-rc.77"
 
 __all__ = ["parse", "Executor", "Dialects", "Environment"]

--- a/preql/parsing/parse_engine.py
+++ b/preql/parsing/parse_engine.py
@@ -110,7 +110,7 @@ grammar = r"""
     
     grain_clause: "grain" "(" column_list ")"
     
-    address: "address" IDENTIFIER
+    address: "address" ADDRESS
     
     query: "query" MULTILINE_STRING
     
@@ -269,7 +269,8 @@ grammar = r"""
     
     // base language constructs
     IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_\\-\\.\-]*/
-    
+    ADDRESS: /[a-zA-Z_][a-zA-Z0-9_\\-\\.\-\*]*/ | /`[a-zA-Z_][a-zA-Z0-9_\\-\\.\-\*]*`/
+
     MULTILINE_STRING: /\'{3}(.*?)\'{3}/s
     
     DOUBLE_STRING_CHARS: /(?:(?!\${)([^"\\]|\\.))+/+ // any character except "
@@ -456,6 +457,9 @@ class ParseToObjects(Transformer):
         return Metadata(**pairs)
 
     def IDENTIFIER(self, args) -> str:
+        return args.value
+
+    def ADDRESS(self, args) -> str:
         return args.value
 
     def STRING_CHARS(self, args) -> str:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,6 @@
 from preql import Environment
+from preql.core.models import LazyEnvironment
+from pathlib import Path
 
 
 def test_multi_environment():
@@ -21,3 +23,14 @@ const pi <- 3.14;
     )
 
     assert basic.concepts["math.pi"].name == "pi"
+
+
+def test_lazy_import():
+    base = Environment()
+
+    env = LazyEnvironment(
+        load_path=Path(__file__).parent / "stack_overflow/stackoverflow.preql",
+        working_path=Path(__file__).parent / "stack_overflow/",
+    )
+
+    assert len(env.concepts) > len(base.concepts)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,4 @@
 from preql import Environment
-from preql.core.models import LazyEnvironment
-from pathlib import Path
 
 
 def test_multi_environment():
@@ -23,14 +21,3 @@ const pi <- 3.14;
     )
 
     assert basic.concepts["math.pi"].name == "pi"
-
-
-def test_lazy_import():
-    base = Environment()
-
-    env = LazyEnvironment(
-        load_path=Path(__file__).parent / "stack_overflow/stackoverflow.preql",
-        working_path=Path(__file__).parent / "stack_overflow/",
-    )
-
-    assert len(env.concepts) > len(base.concepts)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -99,3 +99,22 @@ def test_show(test_environment):
         query.content.output_components[0].address
         == test_environment.concepts["order_id"].address
     )
+
+
+def test_bq_address():
+    _, parsed = parse_text(
+        """key user_pseudo_id int;
+key event_time int;
+property event_time.event_date string;
+
+datasource fundiverse (
+    event_date: event_date,
+    user_pseudo_id: user_pseudo_id,
+    event_time: event_time,
+)
+grain (event_time)
+address `preqldata.analytics_411641820.events_*`
+;"""
+    )
+    query = parsed[-1]
+    assert query.address.location == "`preqldata.analytics_411641820.events_*`"


### PR DESCRIPTION
## Description

To enable the public model repo to be more performant without changing current contract, add in a lazily evaluatable dictionary.

Also add a new parsing type for ADDRESS versus IDENTIFIER that supports the * and ` character for wildcard BQ selects.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Changx
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
